### PR TITLE
Add example of ovelapping (key:value) on dicts for Python3

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,3 +15,4 @@
 - rickhau
 - oztalha (github.com/oztalha)
 - nikhiln (github.com/nikhiln)
+- raulcd (github.com/raulcd)

--- a/loopoverlappingdicts.py
+++ b/loopoverlappingdicts.py
@@ -2,7 +2,7 @@
 """loop over dicts that share (some) keys in Python2"""
 
 dctA = {'a': 1, 'b': 2, 'c': 3}
-dctB = {'b': 4, 'c': 5, 'd': 6}
+dctB = {'b': 4, 'c': 3, 'd': 6}
 
 for ky in set(dctA) & set(dctB):
     print(ky)
@@ -10,3 +10,7 @@ for ky in set(dctA) & set(dctB):
 """loop over dicts that share (some) keys in Python3"""
 for ky in dctA.keys() & dctB.keys():
     print(ky)
+
+"""loop over dicts that share (some) keys and values in Python3"""
+for item in dctA.items() & dctB.items():
+    print(item)


### PR DESCRIPTION
In Python 3 if dicts have overlapping (key: value) pairs you can have them with the dict_items_view and binary operator:

```
for item in dctA.items() & dctB.items():
    print(item)
```
