### PR TITLE
Adds Python 2 flatten list example

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -25,3 +25,4 @@
 - Skycker (github.com/Skycker)
 - vvscloud (github.com/vvscloud)
 - xamvolagis (github.com/xamvolagis)
+- richardasaurus (richard@richard.do)

--- a/flattenlist.py
+++ b/flattenlist.py
@@ -2,7 +2,7 @@
 """
 Deep flattens a nested list
 
-Examples: 
+Examples:
     >>> list(flatten_list([1, 2, [3, 4], [5, 6, [7]]]))
     [1, 2, 3, 4, 5, 6, 7]
     >>> list(flatten_list(['apple', 'banana', ['orange', 'lemon']]))
@@ -15,3 +15,7 @@ def flatten_list(L):
             yield from flatten_list(item)
         else:
             yield item
+
+# In Python 2
+from compiler.ast import flatten
+flatten(L)


### PR DESCRIPTION
Adds a Python 2 only example since the `compiler.ast` module was discontinued in Python 3.