### PR TITLE
Comment blocks can be turn on and off in one  '#'

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -32,3 +32,4 @@
 - awsh (github.com/awsh)
 - shiyanhui (github.com/shiyanhui)
 - pussbb (github.com/pussbb)
+- flint (github.com/flintforge)

--- a/commentblock_onecharswitch.py
+++ b/commentblock_onecharswitch.py
@@ -1,0 +1,13 @@
+#! /usr/bin/env python3
+""" comment blocks can be turn on and off 
+    with one character switch when preceded by #"""
+
+#"""
+print('see me ?')
+#"""
+
+"""
+print('see me too ?')
+#"""
+
+print('continue')

--- a/commentblock_onecharswitch.py
+++ b/commentblock_onecharswitch.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python3
-""" comment blocks can be turn on and off 
-    with one character switch when preceded by #"""
+""" 
+comment blocks can be turn on and off 
+in one character switch when preceded by #"""
 
 #"""
 print('see me ?')


### PR DESCRIPTION
Hi, 
I found an other usefull trick : 

Comment blocks can be turn on and off in one  '#'
When the wrapping blocks are #"""

example :
```
#"""
print('something')
#"""
```
 