### PR TITLE
Add a new method to copy a list

### DIFF
--- a/copylist.py
+++ b/copylist.py
@@ -10,7 +10,7 @@ print(a[:])
 """adding an empty list yields a copy of initial list"""
 
 a = [1, 2, 3, 4, 5]
-print(a + [])  # in python3, for small lists performs faster than the method above
+print(a + [])  # in python3, for small lists performs faster than a[:]
 
 
 """copy list by typecasting method"""

--- a/copylist.py
+++ b/copylist.py
@@ -20,9 +20,15 @@ print(list(a))
 
 
 """using the list.copy() method (python3 only)"""
+
 if sys.version_info.major == 3:
     a = [1, 2, 3, 4, 5]
     print(a.copy())
+else:
+    # in python2 there exists the `copy` builtin module
+    from copy import copy
+    a = [1, 2, 3, 4, 5]
+    print(copy(a))
 
 
 """copy nested lists using copy.deepcopy"""

--- a/copylist.py
+++ b/copylist.py
@@ -7,6 +7,12 @@ a = [1, 2, 3, 4, 5]
 print(a[:])
 
 
+"""adding an empty list yields a copy of initial list"""
+
+a = [1, 2, 3, 4, 5]
+print(a + [])  # in python3, for small lists performs faster than the method above
+
+
 """copy list by typecasting method"""
 
 a = [1, 2, 3, 4, 5]


### PR DESCRIPTION
Add a new method to obtain a shallow array copy and a python2 equivalent for `list.copy()`.