### PR TITLE
Make this example more meaningful/fix bug

### DIFF
--- a/contextmanagers.py
+++ b/contextmanagers.py
@@ -12,25 +12,29 @@ import contextlib
 
 @contextlib.contextmanager
 def unlock(resource):
-    resource = "unlocked"
+    resource.locked = False
     try:
-        yield resource
+        yield
     finally:
-        resource = "locked"
+        resource.locked = True
 
 
 # a resource that is locked
-resource = "locked" 
+class Resource:
+  def __init__(self):
+    self.locked = True
+
+resource = Resource()
 
 # test that it is indeed locked
-print(resource)
+print(resource.locked)
 
 # call your 'unlock' context manager with your resource
-with unlock(resource) as unlocked:
-    print(unlocked) # check that it is unlocked
+with unlock(resource):
+    print(resource.locked) # check that it is unlocked
 
 # ensure it was re-locked when it left the 'unlock' context
-print(resource)
+print(resource.locked)
 
 
 


### PR DESCRIPTION
By doing:

```
@contextlib.contextmanager
def unlock(resource):
    resource = 'unlocked'
    ...
```
We don't really change  the `resource` that is passed in. Because Python is pass by object reference, doing a re-assignment operation does not actually change the `resource` i.e. `resource = 'unlocked'` does not really work. Furthermore, the `resource` variable, with which the `unlock` function is called, is a string; strings are immutable; thus, we need to pass in a mutable data type as the `resource` to be able to demonstrate the resource's "lock state" changing. While we could have used a simple "box" tactic i.e. `resource = ['locked']`, this seemed to distract from the goal of the example. Consequently, it seemed using a small class might be clearer without detracting from the example's value.