### PR TITLE
docs: fix simple typo, recieves -> receives

### DIFF
--- a/metatable.py
+++ b/metatable.py
@@ -1,5 +1,5 @@
 """
-metatable with where the function recieves the dictionary and key.
+metatable with where the function receives the dictionary and key.
 """
 from collections import defaultdict
 


### PR DESCRIPTION
There is a small typo in metatable.py.

Should read `receives` rather than `recieves`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md